### PR TITLE
Incorrect syntax bug

### DIFF
--- a/src/targets/Logary.Targets.DB.Migrations/Migrations.fs
+++ b/src/targets/Logary.Targets.DB.Migrations/Migrations.fs
@@ -17,7 +17,7 @@ type MetricsTable() =
       .WithColumn("Host").AsString(255).NotNullable()
         .WithColumnDescription("Hostname/DNS name of sender")
       .WithColumn("Path").AsString(255).NotNullable().WithDefaultValue(String.Empty)
-        .WithColumnDescription("Where's the metric taken from; see graphite type paths")
+        .WithColumnDescription("Where''s the metric taken from; see graphite type paths")
       .WithColumn("EpochTicks").AsInt64()
         .WithColumnDescription("No. of ticks since Unix Epoch. 1 tick = 100 ns = 10 000 ms")
       .WithColumn("Level").AsInt16().NotNullable()


### PR DESCRIPTION
Bug with SQL Server.

> Error 102: Incorrect syntax near 's'.
> Unclosed quotation mark after the character string ''.

and following configuration:

```
    var x = LogaryFactory.New("Logary Specs",
        with => with
            .Target<Logary.Targets.DB.Builder>("db",
                conf => conf.Target
                    .ConnectionFactory(() => new SqlConnection("some connection string"))
                    .DefaultSchema()
                    .MigrateUp(
                        conn => new SqlServerProcessor(conn,
                            new SqlServer2008Generator(),
                            new ConsoleAnnouncer(),
                            new MigrationOptions(false, "", 60),
                            new SqlServerDbFactory())))
        );
```
